### PR TITLE
fix workspace; fix warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-workspace = { members = ["sixel_test"] }
+#workspace = { members = ["sixel_test"] }
 [package]
 name = "icy_sixel"
 version = "0.1.2"

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -6,7 +6,6 @@
  *****************************************************************************/
 
 use std::cmp::Ordering;
-use std::os::unix::raw::nlink_t;
 use std::vec;
 
 #[derive(Clone)]


### PR DESCRIPTION
Project didn't compile because of the `workspace = { members = ["sixel_test"] }` line introduced when fixing #2, without the accompanying tests, so I've commented it out.

Also there was an unused import.