### PR TITLE
chore: disable unused quantette features

### DIFF
--- a/crates/icy_sixel/Cargo.toml
+++ b/crates/icy_sixel/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["encoding", "graphics", "multimedia::images"]
 readme = "README.md"
 
 [dependencies]
-quantette = "0.5.1"
+quantette = { version = "0.5.1", default-features = false, features = ["kmeans"] }
 thiserror = "2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This disabled all default features for `quantette` and enabled only `kmeans` (which I presume is used somewhere by consumers of `icy_sixel`). This causes the number of dependencies (for normal non dev builds) to drop from 60 to 46.

Based on [their docs](https://docs.rs/quantette/latest/quantette/) there's also features `threads` (which seems to require explicitly using a parallel pipeline and that's not the case here), and `image` which doesn't seem to be used here. The only re-exported type for that crate here is `QuantizeMethod` which is the one that exposes `Kmeans` so I kept the `kmeans` feature because of that.